### PR TITLE
Support MTGA 2021.3.14

### DIFF
--- a/src/HackF5.UnitySpy/Offsets/MonoLibraryOffsets.cs
+++ b/src/HackF5.UnitySpy/Offsets/MonoLibraryOffsets.cs
@@ -83,6 +83,68 @@ namespace HackF5.UnitySpy.Offsets
             VTable = 0x28 + 0x18,
         };
 
+        public static readonly MonoLibraryOffsets Unity2021_3_14_x64_PE_Offsets = new MonoLibraryOffsets
+        {
+            UnityVersions = new List<UnityVersion>() { UnityVersion.Version2021_3_14 },
+            Is64Bits = true,
+            Format = BinaryFormat.PE,
+            MonoLibrary = "mono-2.0-bdwgc.dll",
+
+            // offset in _MonoAssembly to field 'image' (Type MonoImage*)
+            AssemblyImage = 0x10 + 0x50,
+
+            // field 'domain_assemblies' in _MonoDomain (domain-internals.h)
+            ReferencedAssemblies = 0xa0,
+
+            // field 'class_cache' in _MonoImage
+            ImageClassCache = 0x4d0,
+            HashTableSize = 0xc + 0xc,
+            HashTableTable = 0x14 + 0xc,
+
+            // _MonoClass
+            // instance_size
+            TypeDefinitionFieldSize = 0x10 + 0x10,
+
+            // starting from size_inited, valuetype, enumtype
+            TypeDefinitionBitFields = 0x14 + 0xc,
+            // class_kind
+            TypeDefinitionClassKind = 0x1b,                   // alt: 0x1e + 0xc
+            // parent
+            TypeDefinitionParent = 0x30,
+            // nested_in
+            TypeDefinitionNestedIn = 0x38,
+            // name
+            TypeDefinitionName = 0x48,
+            // name_space
+            TypeDefinitionNamespace = 0x50,                      // 0x48 + 0x8
+            // vtable_size
+            TypeDefinitionVTableSize = 0x5C,                    // 0x50 + 0x8 + 0x4
+            // sizes
+            TypeDefinitionSize = 0x90,                                  // Static Fields / Array Element Count / Generic Param Types
+            // fields
+            TypeDefinitionFields = 0x98,                                // 0x98
+            // _byval_arg
+            TypeDefinitionByValArg = 0xB8,                       // 0x98 + 0x10 (2 ptr) + 0x10 (sizeof(MonoType))
+            // runtime_info
+            TypeDefinitionRuntimeInfo = 0x84 + 0x34 + 0x18,             // 0xD0
+
+            // MonoClassDef
+            //   field_count
+            TypeDefinitionFieldCount = 0xa4 + 0x34 + 0x18 + 0x10,       // 0xE0
+            //   next_class_cache
+            TypeDefinitionNextClassCache = 0xa8 + 0x34 + 0x18 + 0x10 + 0x4,    // 0xE4
+
+            TypeDefinitionMonoGenericClass = 0x94 + 0x34 + 0x18 + 0x10,
+            TypeDefinitionGenericContainer = 0x110,
+
+            TypeDefinitionRuntimeInfoDomainVTables = 0x2 + 0x6,  // 2 byte 'max_domain' + allignment to pointer size
+
+            // MonoVTable.vtable
+            // 5 ptr + 8 byte (max_interface_id -> gc_bits) + 8 bytes (4 + 4 padding) + 2 ptr
+            // 0x28 + 0x8 + 0x8 + 0x10
+            VTable = 0x48,
+        };
+
         public static readonly MonoLibraryOffsets Unity2019_4_2020_3_x64_MachO_Offsets = new MonoLibraryOffsets
         {
             UnityVersions = new List<UnityVersion> { UnityVersion.Version2019_4_5 },
@@ -125,6 +187,7 @@ namespace HackF5.UnitySpy.Offsets
             Unity2018_4_10_x86_PE_Offsets,
             Unity2019_4_2020_3_x64_PE_Offsets,
             Unity2019_4_2020_3_x64_MachO_Offsets,
+            Unity2021_3_14_x64_PE_Offsets,
         };
 
         public List<UnityVersion> UnityVersions { get; private set; }
@@ -184,7 +247,7 @@ namespace HackF5.UnitySpy.Offsets
         // MonoClassRuntimeInfo Offsets
         public int TypeDefinitionRuntimeInfoDomainVTables { get; private set; }
 
-        // MonoVTable Offsets
+        /// <summary>Offset of field vtable in MonoVTable</summary>
         public int VTable { get; private set; }
 
         public static MonoLibraryOffsets GetOffsets(string gameExecutableFilePath, bool force = true)
@@ -333,7 +396,7 @@ namespace HackF5.UnitySpy.Offsets
                         }
 
                         Console.WriteLine(unsupportedMsg);
-                        Console.WriteLine($"Offsets of {bestCandidateUnityVersion.ToString()} selected instead.");
+                        Console.WriteLine($"Offsets of {bestCandidateUnityVersion} selected instead.");
 
                         return bestCandidate;
                     }

--- a/src/HackF5.UnitySpy/Offsets/UnityVersion.cs
+++ b/src/HackF5.UnitySpy/Offsets/UnityVersion.cs
@@ -8,6 +8,7 @@ namespace HackF5.UnitySpy.Offsets
         public static readonly UnityVersion Version2018_4_10 = new UnityVersion(2018, 4, 10);
         public static readonly UnityVersion Version2019_4_5 = new UnityVersion(2019, 4, 5);
         public static readonly UnityVersion Version2020_3_13 = new UnityVersion(2020, 3, 13);
+        public static readonly UnityVersion Version2021_3_14 = new UnityVersion(2021, 3, 14);
 
         public UnityVersion(int year, int versionWithinYear, int subversionWithinYear)
         {

--- a/src/mtga-tracker-daemon/HttpServer.cs
+++ b/src/mtga-tracker-daemon/HttpServer.cs
@@ -115,7 +115,7 @@ namespace MTGATrackerDaemon
                     {
                         DateTime startTime = DateTime.Now;
                         IAssemblyImage assemblyImage = CreateAssemblyImage();
-                        object[] cards = assemblyImage["WrapperController"]["<Instance>k__BackingField"]["<InventoryManager>k__BackingField"]["_inventoryServiceWrapper"]["<Cards>k__BackingField"]["entries"];
+                        object[] cards = assemblyImage["WrapperController"]["<Instance>k__BackingField"]["<InventoryManager>k__BackingField"]["_inventoryServiceWrapper"]["<Cards>k__BackingField"]["_entries"];
 
                         StringBuilder cardsArrayJSON = new StringBuilder("[");
                         


### PR DESCRIPTION
- Add Unity 2021.3.14 x64 offsets
  Confirmed working with Magic The Gathering: Arena 2024.35.10.
- Fix collection reading
  The dictionary field was renamed: 'entries' -> '_entries'.