### PR TITLE
Add /allcards endpoint for card export functionality

### DIFF
--- a/src/mtga-tracker-daemon/mtga-tracker-daemon.csproj
+++ b/src/mtga-tracker-daemon/mtga-tracker-daemon.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyVersion>1.0.7.4</AssemblyVersion>
   </PropertyGroup>
   
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Add new /allcards REST endpoint that exports all MTGA cards with titles
- Access MTGA SQLite database directly via memory inspection
- Upgrade to .NET 8.0 for better performance and modern features
- Add Microsoft.Data.Sqlite dependency for database access
- Include JsonEscape utility for safe JSON string handling
- Return cards with grpId and localized titles, plus execution time metrics

Note : I didn't update daemonVersion (1.0.7.4), maybe this could be 1.0.8 if you're ok
Note 2 : I don't know if the switch to .NET 8.0 is required ; it was on my system, not sure why though.